### PR TITLE
results-list: Add availability link to the search-results page

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,5 @@
 require('./js/oadoi-link.module.js')
 module.exports = 'oadoi'
+
+require('./js/oadoi-link-results.module.js')
+module.exports = 'oadoiResults'

--- a/js/oadoi-link-results.module.js
+++ b/js/oadoi-link-results.module.js
@@ -3,15 +3,15 @@ angular
   .component('prmSearchResultAvailabilityLineAfter', {
     bindings: { parentCtrl: '<'},
     template: `
-      <oadoi-results ng-if="{{$ctrl.showOnResultsPage}} && !{{$ctrl.isFullView}}">
+      <oadoi-results ng-if="$ctrl.show">
         <div layout="flex" ng-if="$ctrl.best_oa_link" class="layout-row" style="margin-top: 5px;">
           <prm-icon icon-type="svg" svg-icon-set="action" icon-definition="ic_lock_open_24px"></prm-icon>
           <a class="arrow-link-button md-primoExplore-theme md-ink-ripple" style="margin-left: 3px; margin-top: 3px;"
              target="_blank" href="{{$ctrl.best_oa_link}}"><strong>Open Access</strong> available via unpaywall</a>
           <prm-icon link-arrow icon-type="svg" svg-icon-set="primo-ui" icon-definition="chevron-right"></prm-icon>
         </div>
-        <div class="layout-row">
-          <table ng-if="$ctrl.debug">
+        <div ng-if="$ctrl.debug" class="layout-row">
+          <table>
             <tr><td><strong>doi</strong></td><td>{{$ctrl.doi}}</td></tr>
             <tr><td><strong>is_OA</strong></td><td>{{$ctrl.is_oa}}</td>
             <tr><td><strong>best_oa_link</strong></td><td>{{$ctrl.best_oa_link}}</td></tr>
@@ -20,11 +20,15 @@ angular
       </oadoi-results>`,
     controller:
       function oadoiResultsCtrl(oadoiOptions, $scope, $element, $http) {
-        // ensure that preference is set to display
+        // get data from oadoiOptions
         var self = this;
-        self.showOnResultsPage = oadoiOptions.showOnResultsPage;
-        if(!self.showOnResultsPage){ return; }
         self.debug = oadoiOptions.debug;
+        var showOnResultsPage = oadoiOptions.showOnResultsPage;
+
+        // ensure that preference is set to display
+        var onFullView = this.parentCtrl.isFullView || this.parentCtrl.isOverlayFullView;
+        self.show = showOnResultsPage && !onFullView;
+        if(!showOnResultsPage){ return; }
 
         // get the item from the component's parent controller
         var item = this.parentCtrl.result;

--- a/js/oadoi-link-results.module.js
+++ b/js/oadoi-link-results.module.js
@@ -1,0 +1,53 @@
+angular
+  .module('oadoiResults', [])
+  .component('prmSearchResultAvailabilityLineAfter', {
+    bindings: { parentCtrl: '<'},
+    template: `
+      <oadoi-results ng-if="!{{$ctrl.isFullView}}">
+        <div layout="flex" ng-if="$ctrl.best_oa_link" class="layout-row" style="margin-top: 5px;">
+          <prm-icon icon-type="svg" svg-icon-set="action" icon-definition="ic_lock_open_24px"></prm-icon>
+          <a class="arrow-link-button md-primoExplore-theme md-ink-ripple" style="margin-left: 3px; margin-top: 3px;"
+             target="_blank" href="{{$ctrl.best_oa_link}}"><strong>Open Access</strong> available via unpaywall</a>
+          <prm-icon link-arrow icon-type="svg" svg-icon-set="primo-ui" icon-definition="chevron-right"></prm-icon>
+        </div>
+        <div class="layout-row">
+          <table ng-if="$ctrl.debug">
+            <tr><td><strong>doi</strong></td><td>{{$ctrl.doi}}</td></tr>
+            <tr><td><strong>is_OA</strong></td><td>{{$ctrl.is_oa}}</td>
+            <tr><td><strong>best_oa_link</strong></td><td>{{$ctrl.best_oa_link}}</td></tr>
+          </table>
+        </div>
+      </oadoi-results>`,
+    controller:
+      function unpaywallController(oadoiOptions, $scope, $element, $http) {
+        var self = this;
+        var item = this.parentCtrl.result;
+        self.debug = oadoiOptions.debug;
+        try{
+
+          // obtain doi and open access information from the item PNX (metadata)
+          var addata = item.pnx.addata;
+          if(addata){
+            this.doi = addata.hasOwnProperty("doi")? addata.doi[0] : null; //default to first doi (list)
+            this.is_oa = addata.hasOwnProperty("oa"); //true if property is present at all (regardless of value)
+          }
+
+          // if there's a doi and it's not already open access, ask the oadoi.org for an OA link
+          if(this.doi && !this.is_oa){
+            $http.get("https://api.oadoi.org/v2/"+this.doi+"?email="+oadoiOptions.email)
+              .then(function(response){
+                // if there is a link, save it so it can be used in the template above
+                self.best_oa_link = (response.data.best_oa_location)? response.data.best_oa_location.url : "";
+              }, function(error){
+                if(self.debug){
+                  console.log(error);
+                }
+              });
+          }
+        }catch(e){
+          if(self.debug){
+            console.log("error caught in unpaywallController: " + e);
+          }
+        }
+      }
+  });

--- a/js/oadoi-link-results.module.js
+++ b/js/oadoi-link-results.module.js
@@ -3,7 +3,7 @@ angular
   .component('prmSearchResultAvailabilityLineAfter', {
     bindings: { parentCtrl: '<'},
     template: `
-      <oadoi-results ng-if="!{{$ctrl.isFullView}}">
+      <oadoi-results ng-if="{{$ctrl.showOnResultsPage}} && !{{$ctrl.isFullView}}">
         <div layout="flex" ng-if="$ctrl.best_oa_link" class="layout-row" style="margin-top: 5px;">
           <prm-icon icon-type="svg" svg-icon-set="action" icon-definition="ic_lock_open_24px"></prm-icon>
           <a class="arrow-link-button md-primoExplore-theme md-ink-ripple" style="margin-left: 3px; margin-top: 3px;"
@@ -19,10 +19,15 @@ angular
         </div>
       </oadoi-results>`,
     controller:
-      function unpaywallController(oadoiOptions, $scope, $element, $http) {
+      function oadoiResultsCtrl(oadoiOptions, $scope, $element, $http) {
+        // ensure that preference is set to display
         var self = this;
-        var item = this.parentCtrl.result;
+        self.showOnResultsPage = oadoiOptions.showOnResultsPage;
+        if(!self.showOnResultsPage){ return; }
         self.debug = oadoiOptions.debug;
+
+        // get the item from the component's parent controller
+        var item = this.parentCtrl.result;
         try{
 
           // obtain doi and open access information from the item PNX (metadata)
@@ -46,7 +51,7 @@ angular
           }
         }catch(e){
           if(self.debug){
-            console.log("error caught in unpaywallController: " + e);
+            console.log("error caught in oadoiResultsCtrl: " + e);
           }
         }
       }

--- a/js/oadoi-link.module.js
+++ b/js/oadoi-link.module.js
@@ -13,7 +13,7 @@ angular
 
         	if (obj.hasOwnProperty("doi")){
         		var doi=obj.doi[0];
-            if(debug){ console.log("doi:"+doi); }
+						if(debug){ console.log("doi:"+doi); }
 
     				if (doi && section=="getit_link1_0"){
     					var url="https://api.oadoi.org/v2/"+doi+"?email="+email;

--- a/js/oadoi-link.module.js
+++ b/js/oadoi-link.module.js
@@ -1,7 +1,7 @@
 angular
   .module('oadoi', [])
   .component('prmFullViewServiceContainerAfter', {
-  bindings: { parentCtrl: '<' },
+    bindings: { parentCtrl: '<' },
     controller: function controller($scope, $http, $element, oadoiService, oadoiOptions) {
         this.$onInit = function() {
         	$scope.oaDisplay=false; /* default hides template */
@@ -9,25 +9,28 @@ angular
           var email=oadoiOptions.email;
         	var section=$scope.$parent.$ctrl.service.scrollId;
         	var obj=$scope.$ctrl.parentCtrl.item.pnx.addata;
+          var debug=oadoiOptions.debug;
 
         	if (obj.hasOwnProperty("doi")){
         		var doi=obj.doi[0];
-        		console.log("doi:"+doi)
+            if(debug){ console.log("doi:"+doi); }
 
     				if (doi && section=="getit_link1_0"){
     					var url="https://api.oadoi.org/v2/"+doi+"?email="+email;
 
               var response=oadoiService.getOaiData(url).then(function(response){
-                console.log("it worked");
-                console.log(response);
+                if(debug){
+                  console.log("response from oadoiService received:");
+                  console.log(response);
+                }
                 var oalink=response.data.best_oa_location.url;
-                console.log(oalink);
                 if(oalink===null){
                   $scope.oaDisplay=false;
-                  console.log("it's false");
+                  if(debug){ console.log("oaDisplay set to false (no link returned)"); }
                   $scope.oaClass="ng-hide";
                 }
                 else{
+                  if(debug){ console.log("oalink from response: " + oalink); }
                   $scope.oalink=oalink;
                   $scope.oaDisplay=true;
                   $element.children().removeClass("ng-hide"); /* initially set by $scope.oaDisplay=false */
@@ -35,8 +38,6 @@ angular
                 }
 
               });
-
-
     				}
     				else{$scope.oaDisplay=false;
     				}


### PR DESCRIPTION
### Background
- in order to increase visibility of the unpaywalled links, we wanted to add them to the results list and not just the full view
- others may not want this and we don't want to make this automatically show up without their explicitly setting it, so we hid it behind a new `oadoiOptions.showOnResultsPage` option

### Screenshot
![screen-shot_results-view](https://user-images.githubusercontent.com/5565284/45643509-3fe41c00-ba89-11e8-8fc6-543d53d34442.png)

### Description of Changes
- create a new (standalone) `oadoi-link-results.module.js` file/module
- update `index.js` to export both separately